### PR TITLE
Fix catching exceptions by value in the test code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,17 @@ matrix:
       dist: xenial
       compiler: clang
 
-    - name: "Ubuntu 16.04 Xenial GCC 6"
+    - name: "Ubuntu 18.04 Bionic GCC 7"
+      os: linux
+      dist: bionic
+      compiler: gcc
+
+    - name: "Ubuntu 18.04 Bionic Clang 7"
+      os: linux
+      dist: bionic
+      compiler: clang
+
+    - name: "Linux GCC 6"
       os: linux
       dist: xenial
       compiler: gcc
@@ -54,7 +64,7 @@ matrix:
           packages: g++-6
       env: MATRIX_EVAL="CXX=g++-6"
 
-    - name: "Ubuntu 16.04 Xenial GCC 7"
+    - name: "Linux GCC 7"
       os: linux
       dist: xenial
       compiler: gcc
@@ -63,6 +73,24 @@ matrix:
           sources: ubuntu-toolchain-r-test
           packages: g++-7
       env: MATRIX_EVAL="CXX=g++-7"
+
+    - name: "Linux GCC 8"
+      os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources: ubuntu-toolchain-r-test
+          packages: g++-8
+      env: MATRIX_EVAL="CXX=g++-8"
+
+    - name: "Linux GCC 9"
+      os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources: ubuntu-toolchain-r-test
+          packages: g++-9
+      env: MATRIX_EVAL="CXX=g++-9"
 
     - name: "macOS 10.11 Apple LLVM version 8.0.0"
       os: osx
@@ -77,6 +105,11 @@ matrix:
     - name: "macOS 10.13 Apple LLVM version 10.0.0"
       os: osx
       osx_image: xcode10.1
+      compiler: clang
+
+    - name: "macOS 10.14 Apple LLVM version 11.0.0"
+      os: osx
+      osx_image: xcode11.3
       compiler: clang
 
 before_install:

--- a/csvstream_test.cpp
+++ b/csvstream_test.cpp
@@ -149,7 +149,7 @@ void test_emptyfields() {
     while (csvin >> row) {
       output_observed.push_back(row);
     }
-  } catch(csvstream_exception e) {
+  } catch(const csvstream_exception &e) {
     cout << e.what() << endl;
     assert(0);
   }
@@ -183,7 +183,7 @@ void test_tsv() {
     while (csvin >> row) {
       output_observed.push_back(row);
     }
-  } catch(csvstream_exception e) {
+  } catch(const csvstream_exception &e) {
     cout << e.what() << endl;
     assert(0);
   }
@@ -207,7 +207,7 @@ void test_too_few_cols_in_the_middle_strict() {
   map<string, string> row;
   try {
     while (csvin >> row); // throw away data
-  } catch(csvstream_exception e) {
+  } catch(const csvstream_exception &e) {
     //if we caught an exception, then it worked
     return;
   }
@@ -231,7 +231,7 @@ void test_too_few_cols_in_the_middle_notstrict() {
   map<string, string> row;
   try {
     while (csvin >> row); // throw away data
-  } catch(csvstream_exception e) {
+  } catch(const csvstream_exception &e) {
     // If we caught an exception, then strict=false failed to coerce the number
     // of values.
     assert(0);
@@ -252,7 +252,7 @@ void test_too_few_cols_at_the_end_strict() {
   map<string, string> row;
   try {
     while (csvin >> row); // throw away data
-  } catch(csvstream_exception e) {
+  } catch(const csvstream_exception &e) {
     //if we caught an exception, then it worked
     return;
   }
@@ -275,7 +275,7 @@ void test_too_few_cols_at_the_end_notstrict() {
   map<string, string> row;
   try {
     while (csvin >> row); // throw away data
-  } catch(csvstream_exception e) {
+  } catch(const csvstream_exception &e) {
     // If we caught an exception, then strict=false failed to coerce the number
     // of values.
     assert(0);
@@ -296,7 +296,7 @@ void test_too_many_cols_strict() {
   map<string, string> row;
   try {
     while (csvin >> row); // throw away data
-  } catch(csvstream_exception e) {
+  } catch(const csvstream_exception &e) {
     //if we caught an exception, then it worked
     return;
   }
@@ -320,7 +320,7 @@ void test_too_many_cols_notstrict() {
   map<string, string> row;
   try {
     while (csvin >> row); // throw away data
-  } catch(csvstream_exception e) {
+  } catch(const csvstream_exception &e) {
     // If we caught an exception, then strict=false failed to coerce the number
     // of values.
     assert(0);
@@ -353,7 +353,7 @@ void test_no_newline_at_the_end() {
     while (csvin >> row) {
       output_observed.push_back(row);
     }
-  } catch(csvstream_exception e) {
+  } catch(const csvstream_exception &e) {
     cout << e.what() << endl;
     assert(0);
   }
@@ -386,7 +386,7 @@ void test_quotes() {
     while (csvin >> row) {
       output_observed.push_back(row);
     }
-  } catch(csvstream_exception e) {
+  } catch(const csvstream_exception &e) {
     cout << e.what() << endl;
     assert(0);
   }
@@ -420,7 +420,7 @@ void test_escape_quotes() {
     while (csvin >> row) {
       output_observed.push_back(row);
     }
-  } catch(csvstream_exception e) {
+  } catch(const csvstream_exception &e) {
     cout << e.what() << endl;
     assert(0);
   }
@@ -449,7 +449,7 @@ void test_multiline_quotes() {
     while (csvin >> row) {
       output_observed.push_back(row);
     }
-  } catch(csvstream_exception e) {
+  } catch(const csvstream_exception &e) {
     cout << e.what() << endl;
     assert(0);
   }
@@ -483,7 +483,7 @@ void test_osx_line_endings() {
     while (csvin >> row) {
       output_observed.push_back(row);
     }
-  } catch(csvstream_exception e) {
+  } catch(const csvstream_exception &e) {
     cout << e.what() << endl;
     assert(0);
   }
@@ -517,7 +517,7 @@ void test_windows_line_endings() {
     while (csvin >> row) {
       output_observed.push_back(row);
     }
-  } catch(csvstream_exception e) {
+  } catch(const csvstream_exception &e) {
     cout << e.what() << endl;
     assert(0);
   }
@@ -551,7 +551,7 @@ void test_ordered() {
     while (csvin >> row) {
       output_observed.push_back(row);
     }
-  } catch(csvstream_exception e) {
+  } catch(const csvstream_exception &e) {
     cout << e.what() << endl;
     assert(0);
   }
@@ -585,7 +585,7 @@ void test_strict_notsctrict() {
       while (csvin >> row) {
         output_observed.push_back(row);
       }
-    } catch(csvstream_exception e) {
+    } catch(const csvstream_exception &e) {
       cout << e.what() << endl;
       assert(0);
     }
@@ -618,7 +618,7 @@ void test_notstrict_exceptions() {
     vector<pair<string, string>> row;
     try {
       while (csvin >> row);
-    } catch(csvstream_exception e) {
+    } catch(const csvstream_exception &e) {
       cout << e.what() << endl;
       // If exception was caught, it didn't work
       assert(0);


### PR DESCRIPTION
Catching by value leads to this compilation error with GCC 9:
catching polymorphic type ‘class csvstream_exception’ by value [-Werror=catch-value=]

Fix the compilation error by catching a const reference of the
exception.