### PR TITLE
csvstream.h -> csvstream.hpp

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -23,8 +23,6 @@ jobs:
       # Many are commented out to avoid going over budget
       matrix:
         include:
-          - os: ubuntu-18.04
-            compiler: g++-4.8
           - os: ubuntu-latest
             compiler: g++
           - os: macOS-latest
@@ -36,10 +34,6 @@ jobs:
       # Docs: https://github.com/actions/checkout
       - name: Checkout code
         uses: actions/checkout@v2
-
-      - name: Install old compiler
-        if: ${{ matrix.compiler == 'g++-4.8' }}
-        run: sudo apt-get install g++-4.8
 
       # Run tests
       - name: Run tests

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This example reads one column from a CSV file.
 
 ```c++
 // example1.cpp
-#include "csvstream.h"
+#include "csvstream.hpp"
 #include <iostream>
 #include <string>
 #include <map>
@@ -81,7 +81,7 @@ This example has an outer loop for each row and an inner loop for each column.
 
 ```c++
 //example2.cpp
-#include "csvstream.h"
+#include "csvstream.hpp"
 #include <iostream>
 #include <string>
 #include <map>
@@ -144,7 +144,7 @@ This example uses a vector-of-pair to maintain the order of values read from eac
 
 ```c++
 // example3.cpp
-#include "csvstream.h"
+#include "csvstream.hpp"
 #include <iostream>
 #include <string>
 #include <vector>
@@ -223,7 +223,7 @@ If an error occurs, `csvstream` functions throw a `cstream_exception` .  For exa
 
 ```c++
 // example4.cpp
-#include "csvstream.h"
+#include "csvstream.hpp"
 #include <iostream>
 #include <string>
 #include <map>

--- a/csvstream.hpp
+++ b/csvstream.hpp
@@ -1,7 +1,7 @@
 /* -*- mode: c++ -*- */
 #ifndef CSVSTREAM_H
 #define CSVSTREAM_H
-/* csvstream.h
+/* csvstream.hpp
  *
  * Andrew DeOrio <awdeorio@umich.edu>
  *

--- a/csvstream_test.cpp
+++ b/csvstream_test.cpp
@@ -6,7 +6,7 @@
  * https://github.com/awdeorio/csvstream
  */
 
-#include "csvstream.h"
+#include "csvstream.hpp"
 #include <iostream>
 #include <fstream>
 #include <string>

--- a/example1.cpp
+++ b/example1.cpp
@@ -6,7 +6,7 @@
  * https://github.com/awdeorio/csvstream
  */
 
-#include "csvstream.h"
+#include "csvstream.hpp"
 #include <iostream>
 #include <string>
 #include <map>

--- a/example2.cpp
+++ b/example2.cpp
@@ -6,7 +6,7 @@
  * https://github.com/awdeorio/csvstream
  */
 
-#include "csvstream.h"
+#include "csvstream.hpp"
 #include <iostream>
 #include <string>
 #include <map>

--- a/example3.cpp
+++ b/example3.cpp
@@ -6,7 +6,7 @@
  * https://github.com/awdeorio/csvstream
  */
 
-#include "csvstream.h"
+#include "csvstream.hpp"
 #include <iostream>
 #include <string>
 #include <vector>

--- a/example4.cpp
+++ b/example4.cpp
@@ -6,7 +6,7 @@
  * https://github.com/awdeorio/csvstream
  */
 
-#include "csvstream.h"
+#include "csvstream.hpp"
 #include <iostream>
 #include <string>
 #include <map>


### PR DESCRIPTION
File name change `csvstream.h` to `csvstream.hpp` to be consistent with C++ best practices.

Closes #43 