### PR TITLE
Update Exception Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ int main() {
       cout << row["animal"] << "\n";
     }
   } catch(const csvstream_exception &e) {
-    cerr << "Error: " << e.what() << "\n";
+    cerr << e.what() << "\n";
     return 1;
   }
 }


### PR DESCRIPTION
This PR updates the error example to omit the additional `"Error: "`.

The primary motivation is to match the desired behavior when students use the library in the EECS 280 classifier project.